### PR TITLE
Add a check_operation_status script

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "cSpell.words": [
+    "datatrails"
+  ]
+}

--- a/scitt/check_operation_status.py
+++ b/scitt/check_operation_status.py
@@ -6,17 +6,54 @@ from json import loads as json_loads
 from time import sleep as time_sleep
 
 
-def check_operation_id(
-    operation_id: str
-)-> str:
+# all timeouts and durations are in seconds
+REQUEST_TIMEOUT = 30
+POLL_TIMEOUT = 360
+POLL_INTERVAL = 10
 
-    return subprocess.check_output("curl -s -H @$HOME/.datatrails/bearer-token.txt https://app.datatrails.ai/archivist/v1/publicscitt/operations/" + operation_id, shell=True).decode()
+
+def get_operation_status(operation_id: str) -> str:
+    """
+    gets the operation status from the datatrails API for retrieving operation status
+    """
+
+    # pylint: disable=fixme
+    # TODO: use requests.get, with the request timeout.
+    return subprocess.check_output(
+        # pylint: disable=line-too-long
+        "curl -s -H @$HOME/.datatrails/bearer-token.txt https://app.datatrails.ai/archivist/v1/publicscitt/operations/"
+        + operation_id,
+        shell=True,
+    ).decode()
+
+
+def poll_operation_status(operation_id: str) -> str:
+    """
+    polls for the operation status to be 'succeeded'.
+    """
+
+    poll_attempts: int = int(POLL_TIMEOUT / POLL_INTERVAL)
+
+    for _ in range(poll_attempts):
+        operation_status = get_operation_status(operation_id)
+
+        # pylint: disable=fixme
+        # TODO: ensure get_operation_status handles error cases from the rest request
+        response = json_loads(operation_status)
+        if "status" in response and response["status"] == "succeeded":
+            return response["entryID"]
+
+        time_sleep(POLL_INTERVAL)
+
+    raise TimeoutError("signed statement not registered within polling duration.")
 
 
 def main():
-    """Creates a signed statement"""
+    """Polls for the signed statement to be registered"""
 
-    parser = argparse.ArgumentParser(description="Create a signed statement.")
+    parser = argparse.ArgumentParser(
+        description="Polls for the signed statement to be registered"
+    )
 
     # operation id
     parser.add_argument(
@@ -27,22 +64,8 @@ def main():
 
     args = parser.parse_args()
 
-    # Check the operation status until the status=succeeded
-    # Wait a max of 120 seconds
-    i = 0
-    while i < 120 :
-        retval=check_operation_id(args.operation_id)
-        if retval=="Jwt is expired":
-            print(retval)
-            return
-
-        response = json_loads(check_operation_id(args.operation_id))
-        if "status" in response and response["status"] == "succeeded":
-            print(response["entryID"])
-            break
-
-        time_sleep(1)
-        i+=1
+    entry_id = poll_operation_status(args.operation_id)
+    print(entry_id)
 
 
 if __name__ == "__main__":

--- a/scitt/check_operation_status.py
+++ b/scitt/check_operation_status.py
@@ -23,8 +23,6 @@ def get_token_from_file(token_file_name: str) -> dict:
     with open(token_file_name, mode="r", encoding="utf-8") as token_file:
         auth_header = token_file.read().strip()
         header, value = auth_header.split(": ")
-        print(f"header:{header}")
-        print(f"value:{value}")
         return {header: value}
 
 

--- a/scitt/check_operation_status.py
+++ b/scitt/check_operation_status.py
@@ -5,11 +5,12 @@ import argparse
 from json import loads as json_loads
 from time import sleep as time_sleep
 
+
 def check_operation_id(
     operation_id: str
 )-> str:
 
-    return subprocess.check_output("curl -s -H @$HOME/.datatrails/bearer-token.txt https://app.datatrails.ai/archivist/v1/publicscitt/operations/"+operation_id, shell = True).decode()
+    return subprocess.check_output("curl -s -H @$HOME/.datatrails/bearer-token.txt https://app.datatrails.ai/archivist/v1/publicscitt/operations/" + operation_id, shell=True).decode()
 
 
 def main():
@@ -42,6 +43,7 @@ def main():
 
         time_sleep(1)
         i+=1
+
 
 if __name__ == "__main__":
     main()

--- a/scitt/check_operation_status.py
+++ b/scitt/check_operation_status.py
@@ -1,0 +1,44 @@
+""" Module for checking when a statement has been anchored in the append-only ledger """
+
+import json
+import subprocess
+import argparse
+import time
+
+def check_operation_id(
+  operation_id: str
+)-> str:
+  return subprocess.check_output("curl -s -H @$HOME/.datatrails/bearer-token.txt https://app.datatrails.ai/archivist/v1/publicscitt/operations/"+operation_id, shell=True).decode()
+
+
+def main():
+    """Creates a signed statement"""
+
+    parser = argparse.ArgumentParser(description="Create a signed statement.")
+
+    # signing key file
+    parser.add_argument(
+        "--operation-id",
+        type=str,
+        help="the operation-id from a registered statement",
+    )
+
+    args = parser.parse_args()
+
+    # Check the operation status until the status=succeeded
+    while True:
+      retval=check_operation_id(args.operation_id)
+      if retval=="Jwt is expired":
+        print(retval)
+        return
+
+      response = json.loads(check_operation_id(args.operation_id))
+      if "status" in response and response["status"] == "succeeded":
+        print(response["entryID"])
+        break
+      else:
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scitt/check_operation_status.py
+++ b/scitt/check_operation_status.py
@@ -1,10 +1,9 @@
 """ Module for checking when a statement has been anchored in the append-only ledger """
 
-import json
 import subprocess
 import argparse
-import time
-
+from json import loads as json_loads
+from time import sleep as time_sleep
 
 def check_operation_id(
     operation_id: str
@@ -28,19 +27,21 @@ def main():
     args = parser.parse_args()
 
     # Check the operation status until the status=succeeded
-    while True:
+    # Wait a max of 120 seconds
+    i = 0
+    while i < 120 :
         retval=check_operation_id(args.operation_id)
         if retval=="Jwt is expired":
             print(retval)
             return
 
-        response = json.loads(check_operation_id(args.operation_id))
+        response = json_loads(check_operation_id(args.operation_id))
         if "status" in response and response["status"] == "succeeded":
             print(response["entryID"])
             break
-        else:
-            time.sleep(1)
 
+        time_sleep(1)
+        i+=1
 
 if __name__ == "__main__":
     main()

--- a/scitt/check_operation_status.py
+++ b/scitt/check_operation_status.py
@@ -9,6 +9,7 @@ import time
 def check_operation_id(
     operation_id: str
 )-> str:
+
     return subprocess.check_output("curl -s -H @$HOME/.datatrails/bearer-token.txt https://app.datatrails.ai/archivist/v1/publicscitt/operations/"+operation_id, shell=True).decode()
 
 

--- a/scitt/check_operation_status.py
+++ b/scitt/check_operation_status.py
@@ -10,7 +10,7 @@ def check_operation_id(
     operation_id: str
 )-> str:
 
-    return subprocess.check_output("curl -s -H @$HOME/.datatrails/bearer-token.txt https://app.datatrails.ai/archivist/v1/publicscitt/operations/"+operation_id, shell=True).decode()
+    return subprocess.check_output("curl -s -H @$HOME/.datatrails/bearer-token.txt https://app.datatrails.ai/archivist/v1/publicscitt/operations/"+operation_id, shell = True).decode()
 
 
 def main():

--- a/scitt/check_operation_status.py
+++ b/scitt/check_operation_status.py
@@ -5,10 +5,11 @@ import subprocess
 import argparse
 import time
 
+
 def check_operation_id(
-  operation_id: str
+    operation_id: str
 )-> str:
-  return subprocess.check_output("curl -s -H @$HOME/.datatrails/bearer-token.txt https://app.datatrails.ai/archivist/v1/publicscitt/operations/"+operation_id, shell=True).decode()
+    return subprocess.check_output("curl -s -H @$HOME/.datatrails/bearer-token.txt https://app.datatrails.ai/archivist/v1/publicscitt/operations/"+operation_id, shell=True).decode()
 
 
 def main():
@@ -27,17 +28,17 @@ def main():
 
     # Check the operation status until the status=succeeded
     while True:
-      retval=check_operation_id(args.operation_id)
-      if retval=="Jwt is expired":
-        print(retval)
-        return
+        retval=check_operation_id(args.operation_id)
+        if retval=="Jwt is expired":
+            print(retval)
+            return
 
-      response = json.loads(check_operation_id(args.operation_id))
-      if "status" in response and response["status"] == "succeeded":
-        print(response["entryID"])
-        break
-      else:
-        time.sleep(1)
+        response = json.loads(check_operation_id(args.operation_id))
+        if "status" in response and response["status"] == "succeeded":
+            print(response["entryID"])
+            break
+        else:
+            time.sleep(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The current script can take a while for the statement to get anchored. Rather than continually run the curl, a `check_operation_status.py` script allows the user to run and wait for it to complete.
