### PR TITLE
sketch out what the Azure Code Signing (Trusted Signing Service) demo work around would look like

### DIFF
--- a/acs-openssl-commands/sign.sh
+++ b/acs-openssl-commands/sign.sh
@@ -1,0 +1,7 @@
+openssl genpkey -algorithm RSA -out private_key.pem -pkeyopt rsa_keygen_bits:2048
+openssl req -new -key private_key.pem -out certificate.csr
+openssl x509 -signkey private_key.pem -in certificate.csr -req -days 365 -out certificate.pem
+openssl smime -sign -in payload.txt -out payload.sig -outform DER -signer certificate.pem -inkey private_key.pem -nodetach
+openssl base64 -in payload.sig -out payload_base64.sig
+
+

--- a/acs-openssl-commands/verify.sh
+++ b/acs-openssl-commands/verify.sh
@@ -1,0 +1,1 @@
+openssl smime -verify -in payload.sig -inform DER -CAfile certificate.pem

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pycose~=1.0.1
 ecdsa~=0.18.0
 jwcrypto~=1.5.0
 requests~=2.31.0
+pycryptodome~=3.20.0

--- a/scitt/create_signed_statement.py
+++ b/scitt/create_signed_statement.py
@@ -140,6 +140,38 @@ def main():
         default="scitt-signing-key.pem",
     )
 
+    # If we are stuck with RS256 ( don't think we are now), then we can't do this without backend changes.
+    #
+    # Ideally we would have a single option that took the acs response 'as is' and
+    # 1. picked out the digest that was signed, this becomes the payload
+    # 2. decoded the signatureCertificate, and extracted the public key
+    # 3. called an alternate implementation of create_signed_statement which
+    # 3.a) takes the payload as is
+    # 3.b) puts the public key material in the CNF claim
+    # 3.c) sets the algorithm to PS256. Also we need to actually figure out how to get PS256 from ACS
+
+    # azure code signing service response file
+    parser.add_argument(
+        "--acs-sign-response-file",
+        type=str,
+        help="filepath to the stored, json formated, response from the azure code signing service",
+        default="scitt-acs-sign-response.json",
+    )
+
+    # alternately, we can provide the signature and cert as seperate things
+    parser.add_argument(
+        "--acs-sig-file",
+        type=str,
+        help="filepath to the stored, base64 encoded signed payload",
+        default="scitt-acs-sig.json",
+    )
+    parser.add_argument(
+        "--acs-signature-cert-file",
+        type=str,
+        help="filepath to the stored, base64 encoded signed payload",
+        default="scitt-acs-signed.json",
+    )
+
     # payload-file (a reference to the file that will become the payload of the SCITT Statement)
     parser.add_argument(
         "--payload-file",


### PR DESCRIPTION
Some comments and new options in the main script to illustrate what I think the interface would look like and articulate what I think it needs to do

sign.sh just emulates roughly how to produce an RSA signature of the right sort of shape for testing
verify.sh just shows the result can be verified

