### PR TITLE
Updates for Arch -07 and SCRAPI -03

### DIFF
--- a/scitt/create_signed_statement.py
+++ b/scitt/create_signed_statement.py
@@ -136,14 +136,14 @@ def main():
     parser.add_argument(
         "--detached-hash",
         type=str,
-        help='The hash value to assist in payload verification when the payload-type="detached"'
+        help='The hash value to assist in payload verification when the payload-type="hash"'
     )
 
     # detached-hash-algorithm
     parser.add_argument(
         "--detached-hash-algorithm",
         type=str,
-        help='When the payload-type="detached", an optional detached-hash may be set to assist in payload verification. detached-hash-algorithm identifies the hashing algorithm used'
+        help='When the payload-type="hash", the optional detached-hash must be set to assist in payload verification. detached-hash-algorithm identifies the hashing algorithm used'
     )
 
     # issuer

--- a/scitt/create_signed_statement.py
+++ b/scitt/create_signed_statement.py
@@ -121,7 +121,7 @@ def create_signed_statement(
 def main():
     """Creates a signed statement"""
 
-    parser = argparse.ArgumentParser(description="Create a signed statement.")
+    parser = argparse.ArgumentParser(description="Create a signed statement")
 
     # content-type
     parser.add_argument(
@@ -129,7 +129,7 @@ def main():
         "--content-type",
         type=str,
         help="The iana.org media type for the statement.",
-        default="application/json",
+        default="application/json"
     )
 
     # detached-hash
@@ -139,11 +139,11 @@ def main():
         help='The hash value to assist in payload verification when the payload-type="detached"'
     )
 
-    # detached-hash-type
+    # detached-hash-algorithm
     parser.add_argument(
-        "--detached-hash-type",
+        "--detached-hash-algorithm",
         type=str,
-        help='When the payload-type="detached", an optional detached-hash may be set to assist in payload verification. detached-hash-type identifies the hashing algorithm used'
+        help='When the payload-type="detached", an optional detached-hash may be set to assist in payload verification. detached-hash-algorithm identifies the hashing algorithm used'
     )
 
     # issuer
@@ -166,9 +166,9 @@ def main():
     parser.add_argument(
         "--payload-type",
         type=str,
-        choices=['attached','detached','hash+sha256','hash+sha512'],
-        help='Signed Statements may attach the statement within the payload as attached, detached (nil), or sign a hash of the statement: (attached | detached | hash+[algo "hash+sha256" | "hash+sha512"])',
-        default="hash+sha512",
+        choices=['attached','detached','hash+sha-256','hash+sha-512'],
+        help='Signed Statements may attach the statement within the payload as attached, detached (nil), or sign a hash of the statement: (attached | detached | hash+[algo "hash+sha-256" | "hash+sha-512"])',
+        default="hash+sha-512",
     )
 
     # signing key
@@ -177,7 +177,7 @@ def main():
         "--signing-key-file",
         type=str,
         required=True,
-        help="filepath to the stored ecdsa P-256 signing key, in pem format.",
+        help="filepath to the stored ecdsa P-256 signing key, in pem format",
         default="key.pem",
     )
 

--- a/scitt/create_signed_statement.py
+++ b/scitt/create_signed_statement.py
@@ -162,6 +162,15 @@ def main():
         help="An optional URI the statement is stored"
     )
 
+    # statement-type
+    parser.add_argument(
+        "--payload-type",
+        type=str,
+        choices=['attached','detached','hash+sha256','hash+sha512'],
+        help='Signed Statements may attach the statement within the payload as attached, detached (nil), or sign a hash of the statement: (attached | detached | hash+[algo "hash+sha256" | "hash+sha512"])',
+        default="hash+sha512",
+    )
+
     # signing key
     parser.add_argument(
         "-k",
@@ -197,15 +206,6 @@ def main():
         type=str,
         help="name of the output file for the signed statement",
         default="signed-statement.cbor",
-    )
-
-    # statement-type
-    parser.add_argument(
-        "--payload-type",
-        type=str,
-        choices=['attached','detached','hash+sha256','hash+sha512'],
-        help="Signed Statements may attach the statement within the payload as attached, detached (nil), or sign a hash of the statement: (attached | detached | hash+[algo])",
-        default="hash+sha512",
     )
 
     args = parser.parse_args()

--- a/scitt/create_signed_statement.py
+++ b/scitt/create_signed_statement.py
@@ -136,7 +136,7 @@ def main():
     parser.add_argument(
         "--detached-hash",
         type=str,
-        help='The hash value to assist in payload verification when the a payload-type="detached"'
+        help='The hash value to assist in payload verification when the payload-type="detached"'
     )
 
     # detached-hash-type

--- a/scitt/create_signed_statement.py
+++ b/scitt/create_signed_statement.py
@@ -166,9 +166,9 @@ def main():
     parser.add_argument(
         "--payload-type",
         type=str,
-        choices=['attached','detached','hash+sha-256','hash+sha-512'],
-        help='Signed Statements may attach the statement within the payload as attached, detached (nil), or sign a hash of the statement: (attached | detached | hash+[algo "hash+sha-256" | "hash+sha-512"])',
-        default="hash+sha-512",
+        choices=['attached','detached','hash'],
+        help='Signed Statements may reference a statement within the payload as attached (inline), detached (nil), or set the payload to a hash of the statement: (attached | detached | hash ). When set, detached-hash and detached-hash-algorithm are required',
+        default="hash",
     )
 
     # signing key

--- a/scitt/create_signed_statement.py
+++ b/scitt/create_signed_statement.py
@@ -143,7 +143,7 @@ def main():
     parser.add_argument(
         "--detached-hash-type",
         type=str,
-        help='When the a payload-type="detached", an optional detached-hash may be set to assist in payload verification. detached-hash-type identifies the hashing algorithm used'
+        help='When the payload-type="detached", an optional detached-hash may be set to assist in payload verification. detached-hash-type identifies the hashing algorithm used'
     )
 
     # issuer


### PR DESCRIPTION
Draft PR to outline updates:

NOTE: Updated help output to match the current state of the PR:

```console
usage: create_signed_statement.py \
  --issuer ISSUER \
  -k SIGNING_KEY_FILE \
  -f STATEMENT_FILE \
  -s SUBJECT \
  [-h] [-t CONTENT_TYPE] \
  [--detached-hash DETACHED_HASH] \
  [--detached-hash-algorithm DETACHED_HASH_ALGORITHM] \
  [-l LOCATION_HINT] \
  [--payload-type {attached,detached,hash}] \
  [-o OUTPUT_FILE]

Create a signed statement.

options:
  -h, --help            show this help message and exit
  -t CONTENT_TYPE, --content-type CONTENT_TYPE
                        The iana.org media type for the statement.
  --detached-hash DETACHED_HASH
                        The hash value to assist in payload verification when the payload-type="hash"
  --detached-hash-algorithm DETACHED_HASH_ALGORITHM
                        When the payload-type="hash", the optional detached-hash must be set to assist in payload verification. detached-hash-algorithm identifies
                        the hashing algorithm used
  --issuer ISSUER       Owner of the signing key
  -l LOCATION_HINT, --location-hint LOCATION_HINT
                        An optional URI the statement is stored
  --payload-type {attached,detached,hash}
                        Signed Statements may reference a statement within the payload as attached (inline), detached (nil), or set the payload to a hash of the
                        statement: (attached | detached | hash ). When set, detached-hash and detached-hash-algorithm are required
  -k SIGNING_KEY_FILE, --signing-key-file SIGNING_KEY_FILE
                        filepath to the stored ecdsa P-256 signing key, in pem format
  -f STATEMENT_FILE, --statement-file STATEMENT_FILE
                        filepath to the content that will become the payload of the SCITT Signed Statement
  -s SUBJECT, --subject SUBJECT
                        Unique identifier, owned by the Issuer, for the Artifact the statement references
  -o OUTPUT_FILE, --output-file OUTPUT_FILE
                        name of the output file for the signed statement
```