### PR TITLE
move away from usage of feed

### DIFF
--- a/scitt/create_signed_statement.py
+++ b/scitt/create_signed_statement.py
@@ -17,11 +17,6 @@ from pycose.keys import CoseKey
 
 from ecdsa import SigningKey, VerifyingKey
 
-
-# Feed header label comes from version 2 of the scitt architecture document
-# https://www.ietf.org/archive/id/draft-birkholz-scitt-architecture-02.html#name-envelope-and-claim-format
-HEADER_LABEL_FEED = 392
-
 # CWT header label comes from version 4 of the scitt architecture document
 # https://www.ietf.org/archive/id/draft-ietf-scitt-architecture-04.html#name-issuer-identity
 HEADER_LABEL_CWT = 13
@@ -65,12 +60,12 @@ def open_payload(payload_file: str) -> str:
 def create_signed_statement(
     signing_key: SigningKey,
     payload: str,
-    feed: str,
+    subject: str,
     issuer: str,
     content_type: str,
 ) -> bytes:
     """
-    creates a signed statement, given the signing_key, payload, feed and issuer
+    creates a signed statement, given the signing_key, payload, issuer and subject
     """
 
     verifying_key: Optional[VerifyingKey] = signing_key.verifying_key
@@ -89,10 +84,9 @@ def create_signed_statement(
         Algorithm: Es256,
         KID: b"testkey",
         ContentType: content_type,
-        HEADER_LABEL_FEED: feed,
         HEADER_LABEL_CWT: {
             HEADER_LABEL_CWT_ISSUER: issuer,
-            HEADER_LABEL_CWT_SUBJECT: feed,
+            HEADER_LABEL_CWT_SUBJECT: subject,
             HEADER_LABEL_CWT_CNF: {
                 HEADER_LABEL_CNF_COSE_KEY: {
                     KpKty: KtyEC2,
@@ -157,11 +151,11 @@ def main():
         default="application/json",
     )
 
-    # feed
+    # subject
     parser.add_argument(
-        "--feed",
+        "--subject",
         type=str,
-        help="feed to correlate statements made about an artifact.",
+        help="identifies the artifact that is the subject of the statement, enabling correlation.",
     )
 
     # issuer
@@ -187,7 +181,7 @@ def main():
     signed_statement = create_signed_statement(
         signing_key,
         payload,
-        args.feed,
+        args.subject,
         args.issuer,
         args.content_type,
     )

--- a/unittests/test_create_signed_statement.py
+++ b/unittests/test_create_signed_statement.py
@@ -40,12 +40,12 @@ class TestCreateSignedStatement(unittest.TestCase):
 
         payload = json.dumps(KNOWN_STATEMENT)
 
-        feed = "testfeed"
+        subject = "testsubject"
         issuer = "testissuer"
         content_type = "application/json"
 
         signed_statement = create_signed_statement(
-            signing_key, payload, feed, issuer, content_type
+            signing_key, payload, subject, issuer, content_type
         )
 
         # verify the signed statement


### PR DESCRIPTION
For 07 cwt.subject will be used instead of the feed ID, still allowing for correlation of multiple statements with a single artifact.

re AB#9636