### PR TITLE
Better error handling for receipt signature verification

### DIFF
--- a/scitt/verify_receipt_signature.py
+++ b/scitt/verify_receipt_signature.py
@@ -4,6 +4,7 @@ import re
 import argparse
 
 import requests
+import sys
 
 from jwcrypto import jwk
 
@@ -97,8 +98,12 @@ def verify_receipt(receipt: bytes) -> bool:
     """
 
     # decode the cbor encoded cose sign1 message
-    message = Sign1Message.decode(receipt)
-
+    try:
+        message = Sign1Message.decode(receipt)
+    except: 
+        print("failed to decode cose sign1 receipt", file=sys.stderr)
+        return False
+    
     # get the verification key from didweb
     kid: bytes = message.phdr[KID]
     didurl = message.phdr[HEADER_LABEL_DID]
@@ -135,7 +140,10 @@ def main():
 
     verified = verify_receipt(receipt)
 
-    print(verified)
+    if verified:
+        print("signature verification succeeded")
+    else:
+        print("signature verification failed")
 
 
 if __name__ == "__main__":

--- a/scitt/verify_receipt_signature.py
+++ b/scitt/verify_receipt_signature.py
@@ -100,7 +100,7 @@ def verify_receipt(receipt: bytes) -> bool:
     # decode the cbor encoded cose sign1 message
     try:
         message = Sign1Message.decode(receipt)
-    except (ValueError, AttributeError) as ex:
+    except (ValueError, AttributeError):
         print("failed to decode cose sign1 receipt", file=sys.stderr)
         return False
 

--- a/scitt/verify_receipt_signature.py
+++ b/scitt/verify_receipt_signature.py
@@ -100,7 +100,7 @@ def verify_receipt(receipt: bytes) -> bool:
     # decode the cbor encoded cose sign1 message
     try:
         message = Sign1Message.decode(receipt)
-    except ValueError:
+    except (ValueError, AttributeError):
         print("failed to decode cose sign1 receipt", file=sys.stderr)
         return False
 

--- a/scitt/verify_receipt_signature.py
+++ b/scitt/verify_receipt_signature.py
@@ -2,9 +2,9 @@
 
 import re
 import argparse
+import sys
 
 import requests
-import sys
 
 from jwcrypto import jwk
 
@@ -100,7 +100,7 @@ def verify_receipt(receipt: bytes) -> bool:
     # decode the cbor encoded cose sign1 message
     try:
         message = Sign1Message.decode(receipt)
-    except:
+    except ValueError:
         print("failed to decode cose sign1 receipt", file=sys.stderr)
         return False
 

--- a/scitt/verify_receipt_signature.py
+++ b/scitt/verify_receipt_signature.py
@@ -100,7 +100,7 @@ def verify_receipt(receipt: bytes) -> bool:
     # decode the cbor encoded cose sign1 message
     try:
         message = Sign1Message.decode(receipt)
-    except (ValueError, AttributeError):
+    except (ValueError, AttributeError) as ex:
         print("failed to decode cose sign1 receipt", file=sys.stderr)
         return False
 

--- a/scitt/verify_receipt_signature.py
+++ b/scitt/verify_receipt_signature.py
@@ -100,10 +100,10 @@ def verify_receipt(receipt: bytes) -> bool:
     # decode the cbor encoded cose sign1 message
     try:
         message = Sign1Message.decode(receipt)
-    except: 
+    except:
         print("failed to decode cose sign1 receipt", file=sys.stderr)
         return False
-    
+
     # get the verification key from didweb
     kid: bytes = message.phdr[KID]
     didurl = message.phdr[HEADER_LABEL_DID]


### PR DESCRIPTION
## Testing

Bad cosesign1:

```
failed to decode cose sign1 receipt
signature verification failed
```

re: AB#9689