### PR TITLE
Add a way to decode the event back to the original scitt signed statement payload

### DIFF
--- a/scitt/decode_event.py
+++ b/scitt/decode_event.py
@@ -31,6 +31,7 @@ def get_base64_statement(event_json: bytes) -> str:
 
     return base64_signed_statement
 
+
 def decode_base64_statement(base64_statement: str) -> bytes:
     """
     decodes the base64 encoded signed statement
@@ -38,6 +39,7 @@ def decode_base64_statement(base64_statement: str) -> bytes:
     """
     signed_statement = base64.b64decode(base64_statement)
     return signed_statement
+
 
 def decode_statement(receipt: bytes):
     """

--- a/scitt/decode_event.py
+++ b/scitt/decode_event.py
@@ -1,0 +1,89 @@
+""" Module for decoding the event """
+
+import argparse
+
+import json
+import base64
+
+from pprint import pprint
+
+from pycose.messages import Sign1Message
+
+
+def open_event_json(event_json_file: str) -> bytes:
+    """
+    opens the event json
+    """
+    with open(event_json_file, "rb") as file:
+        event_json = file.read()
+        return event_json
+
+
+def get_base64_statement(event_json: bytes) -> str:
+    """
+    gets the base64 encoded signed statement from
+    the datatrails event
+    """
+
+    event = json.loads(event_json)
+
+    base64_signed_statement = event["event_attributes"]["signed_statement"]
+
+    return base64_signed_statement
+
+def decode_base64_statement(base64_statement: str) -> bytes:
+    """
+    decodes the base64 encoded signed statement
+    into a cbor cose sign1 statement
+    """
+    signed_statement = base64.b64decode(base64_statement)
+    return signed_statement
+
+def decode_statement(receipt: bytes):
+    """
+    decodes the signed statement
+    """
+
+    # decode the cbor encoded cose sign1 message
+    message = Sign1Message.decode(receipt)
+
+    return message
+
+
+def main():
+    """Verifies a counter signed receipt signature"""
+
+    parser = argparse.ArgumentParser(
+        description="Verify a counter signed receipt signature."
+    )
+
+    # signing key file
+    parser.add_argument(
+        "--event-json-file",
+        type=str,
+        help="filepath to the stored event, in json format.",
+    )
+
+    args = parser.parse_args()
+
+    event_json = open_event_json(args.event_json_file)
+
+    base64_signed_statement = get_base64_statement(event_json)
+    print(f"\nbase64 encoded signed statement: \n\n{base64_signed_statement}")
+
+    signed_statement = decode_base64_statement(base64_signed_statement)
+    print(f"\ncbor encoded signed statement: \n\n{signed_statement}")
+
+    decoded_statement = decode_statement(signed_statement)
+
+    print("\ncbor decoded cose sign1 statement:\n")
+    print("protected headers:")
+    pprint(decoded_statement.phdr)
+    print("\nunprotected headers: ")
+    pprint(decoded_statement.uhdr)
+    print("\npayload: ", decoded_statement.payload)
+    print("payload hex: ", decoded_statement.payload.hex())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Overview
* add a sample of how to peel the onion back from datatrails event that is included on the immutable log, all the way back to the original payload the user is trying to protect


## Testing 

Manually tested against a datatrails event:

```
python3 ./scitt/decode_event.py --event-json-file=event.json

base64 encoded signed statement: 

0oRYmaYBJgRHdGVzdGtleQNwYXBwbGljYXRpb24vanNvbg2jAWNmb28CY2JhcgihAaQBAiABIVggjiIe5rk6o52xGXvuwZy5V3Gc941MBEdlIS+XRmZ9Sc8iWCATW7H/ieRgcOEooFog/7MIsWOgw7OvCZptq/wZhoJlIxkD5i8ZA+d4GGh0dHBzOi8vc3RvcmFnZS5leGFtcGxlL6BYIB7u+iOHBv4x79EQgpVWI7TYyDffJwV1N7Z2i61qMbn7WEAwFJX5AwhE3j1G078NJUc0HA0umsqDW0BAqrxTAbQJMUHHjdDyG5OfJpbagHy79cWk8XoaPMt9oZPEV6sr82G5

cbor encoded signed statement: 

b'\xd2\x84X\x99\xa6\x01&\x04Gtestkey\x03papplication/json\r\xa3\x01cfoo\x02cbar\x08\xa1\x01\xa4\x01\x02 \x01!X \x8e"\x1e\xe6\xb9:\xa3\x9d\xb1\x19{\xee\xc1\x9c\xb9Wq\x9c\xf7\x8dL\x04Ge!/\x97Ff}I\xcf"X \x13[\xb1\xff\x89\xe4`p\xe1(\xa0Z \xff\xb3\x08\xb1c\xa0\xc3\xb3\xaf\t\x9am\xab\xfc\x19\x86\x82e#\x19\x03\xe6/\x19\x03\xe7x\x18https://storage.example/\xa0X \x1e\xee\xfa#\x87\x06\xfe1\xef\xd1\x10\x82\x95V#\xb4\xd8\xc87\xdf\'\x05u7\xb6v\x8b\xadj1\xb9\xfbX@0\x14\x95\xf9\x03\x08D\xde=F\xd3\xbf\r%G4\x1c\r.\x9a\xca\x83[@@\xaa\xbcS\x01\xb4\t1A\xc7\x8d\xd0\xf2\x1b\x93\x9f&\x96\xda\x80|\xbb\xf5\xc5\xa4\xf1z\x1a<\xcb}\xa1\x93\xc4W\xab+\xf3a\xb9'

cbor decoded cose sign1 statement:

protected headers:
{<class 'pycose.headers.Algorithm'>: <class 'pycose.algorithms.Es256'>,
 <class 'pycose.headers.ContentType'>: 'application/json',
 <class 'pycose.headers.KID'>: b'testkey',
 13: {1: 'foo',
      2: 'bar',
      8: {1: {-3: b'\x13[\xb1\xff\x89\xe4`p\xe1(\xa0Z \xff\xb3\x08\xb1c\xa0\xc3'
                  b'\xb3\xaf\t\x9am\xab\xfc\x19\x86\x82e#',
              -2: b'\x8e"\x1e\xe6\xb9:\xa3\x9d\xb1\x19{\xee\xc1\x9c\xb9W'
                  b'q\x9c\xf7\x8dL\x04Ge!/\x97Ff}I\xcf',
              -1: 1,
              1: 2}}},
 998: -16,
 999: 'https://storage.example/'}

unprotected headers: 
{}

payload:  b"\x1e\xee\xfa#\x87\x06\xfe1\xef\xd1\x10\x82\x95V#\xb4\xd8\xc87\xdf'\x05u7\xb6v\x8b\xadj1\xb9\xfb"
payload hex:  1eeefa238706fe31efd11082955623b4d8c837df27057537b6768bad6a31b9fb
```