### PR TITLE
Better error handling and logging for get operation status

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 
 # code quality
 autopep8~=2.0
-black~=23.9
+black~=24.4.2
 pycodestyle~=2.10
 pylint~=3.0
 pyright~=1.1

--- a/scitt/check_operation_status.py
+++ b/scitt/check_operation_status.py
@@ -3,6 +3,8 @@
 import os
 import argparse
 import logging
+import traceback
+import sys
 
 from time import sleep as time_sleep
 
@@ -11,7 +13,7 @@ import requests
 
 # all timeouts and durations are in seconds
 REQUEST_TIMEOUT = 30
-POLL_TIMEOUT = 360
+POLL_TIMEOUT = 20
 POLL_INTERVAL = 10
 
 
@@ -119,9 +121,12 @@ def main():
 
     headers = get_token_from_file(args.token_file_name)
 
-    entry_id = poll_operation_status(args.operation_id, headers, logger)
-    print(entry_id)
-
+    try:
+        entry_id = poll_operation_status(args.operation_id, headers, logger)
+        print(entry_id)
+    except TimeoutError as e:
+        print(e, file=sys.stderr)
+        sys.exit(1)
 
 if __name__ == "__main__":
     main()

--- a/scitt/check_operation_status.py
+++ b/scitt/check_operation_status.py
@@ -13,7 +13,7 @@ import requests
 
 # all timeouts and durations are in seconds
 REQUEST_TIMEOUT = 30
-POLL_TIMEOUT = 20
+POLL_TIMEOUT = 60
 POLL_INTERVAL = 10
 
 
@@ -73,7 +73,7 @@ def poll_operation_status(
 
         time_sleep(POLL_INTERVAL)
 
-    raise TimeoutError("signed statement not registered within polling duration.")
+    raise TimeoutError("signed statement not registered within polling duration")
 
 
 def main():

--- a/scitt/check_operation_status.py
+++ b/scitt/check_operation_status.py
@@ -69,7 +69,7 @@ def poll_operation_status(
                 return operation_status["entryID"]
 
         except requests.HTTPError as e:
-            logger.debug(f"failed getting operation status, error: {e}")
+            logger.debug("failed getting operation status, error: %s", e)
 
         time_sleep(POLL_INTERVAL)
 

--- a/scitt/check_operation_status.py
+++ b/scitt/check_operation_status.py
@@ -116,7 +116,7 @@ def main():
     args = parser.parse_args()
 
     logger = logging.getLogger("check operation status")
-    logging.basicConfig(encoding="utf-8", level=logging.getLevelName(args.log_level))
+    logging.basicConfig(level=logging.getLevelName(args.log_level))
 
     headers = get_token_from_file(args.token_file_name)
 

--- a/scitt/check_operation_status.py
+++ b/scitt/check_operation_status.py
@@ -128,5 +128,6 @@ def main():
         print(e, file=sys.stderr)
         sys.exit(1)
 
+
 if __name__ == "__main__":
     main()

--- a/scitt/check_operation_status.py
+++ b/scitt/check_operation_status.py
@@ -108,8 +108,8 @@ def main():
     parser.add_argument(
         "--log-level",
         type=str,
-        help="log level. for any polling errors use DEBUG, defaults to INFO",
-        default="INFO",
+        help="log level. for any individual poll errors use DEBUG, defaults to WARNING",
+        default="WARNING",
     )
 
     args = parser.parse_args()

--- a/scitt/check_operation_status.py
+++ b/scitt/check_operation_status.py
@@ -3,7 +3,6 @@
 import os
 import argparse
 import logging
-import traceback
 import sys
 
 from time import sleep as time_sleep

--- a/unittests/__init__.py
+++ b/unittests/__init__.py
@@ -1,6 +1,7 @@
 """
 Unit tests
 """
+
 import unittest
 
 # Hides Docstring


### PR DESCRIPTION
## Overview
* Catch and handle http exceptions by logging them and carrying on the polling
* Introduce logging and log levels

## Testing

Failure with log level `WARNING`:
```
python3 ./scitt/check_operation_status.py --operation-id foo
signed statement not registered within polling duration
```

Failure with log level `DEBUG`:
```
python3 ./scitt/check_operation_status.py --operation-id foo --log-level DEBUG
INFO:check operation status:starting to poll for operation status 'succeeded'
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): app.datatrails.ai:443
DEBUG:urllib3.connectionpool:https://app.datatrails.ai:443 "GET /archivist/v1/publicscitt/operations/foo HTTP/1.1" 400 47
DEBUG:check operation status:failed getting operation status, error: 400 Client Error: Bad Request for url: https://app.datatrails.ai/archivist/v1/publicscitt/operations/foo
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): app.datatrails.ai:443
DEBUG:urllib3.connectionpool:https://app.datatrails.ai:443 "GET /archivist/v1/publicscitt/operations/foo HTTP/1.1" 400 47
DEBUG:check operation status:failed getting operation status, error: 400 Client Error: Bad Request for url: https://app.datatrails.ai/archivist/v1/publicscitt/operations/foo
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): app.datatrails.ai:443
DEBUG:urllib3.connectionpool:https://app.datatrails.ai:443 "GET /archivist/v1/publicscitt/operations/foo HTTP/1.1" 400 47
DEBUG:check operation status:failed getting operation status, error: 400 Client Error: Bad Request for url: https://app.datatrails.ai/archivist/v1/publicscitt/operations/foo
...
```