### PR TITLE
Sync to hash envelope draft

### DIFF
--- a/scitt/check_operation_status.py
+++ b/scitt/check_operation_status.py
@@ -12,7 +12,7 @@ import requests
 
 # all timeouts and durations are in seconds
 REQUEST_TIMEOUT = 30
-POLL_TIMEOUT = 60
+POLL_TIMEOUT = 120
 POLL_INTERVAL = 10
 
 

--- a/scitt/create_hashed_signed_statement.py
+++ b/scitt/create_hashed_signed_statement.py
@@ -206,7 +206,7 @@ def main():
         payload=payload_contents,
         payload_location=args.payload_location,
         signing_key=signing_key,
-        subject=args.subject
+        subject=args.subject,
     )
 
     with open(args.output_file, "wb") as output_file:

--- a/unittests/test_create_hashed_signed_statement.py
+++ b/unittests/test_create_hashed_signed_statement.py
@@ -50,11 +50,11 @@ class TestCreateHashedSignedStatement(unittest.TestCase):
         payload_location = "example-location"
 
         signed_statement = create_hashed_signed_statement(
-            signing_key=signing_key, 
-            payload=payload, 
-            subject=subject, 
-            issuer=issuer, 
-            content_type=content_type, 
+            signing_key=signing_key,
+            payload=payload,
+            subject=subject,
+            issuer=issuer,
+            content_type=content_type,
             payload_location=payload_location
         )
 

--- a/unittests/test_create_hashed_signed_statement.py
+++ b/unittests/test_create_hashed_signed_statement.py
@@ -55,7 +55,7 @@ class TestCreateHashedSignedStatement(unittest.TestCase):
             subject=subject,
             issuer=issuer,
             content_type=content_type,
-            payload_location=payload_location
+            payload_location=payload_location,
         )
 
         # decode the cbor encoded cose sign1 message

--- a/unittests/test_create_hashed_signed_statement.py
+++ b/unittests/test_create_hashed_signed_statement.py
@@ -21,7 +21,7 @@ from scitt.create_hashed_signed_statement import (
     HEADER_LABEL_CWT_CNF,
     HEADER_LABEL_CNF_COSE_KEY,
     HEADER_LABEL_PAYLOAD_HASH_ALGORITHM,
-    HEADER_LABEL_LOCATION,
+    HEADER_LABEL_PAYLOAD_LOCATION,
 )
 
 from .constants import KNOWN_STATEMENT
@@ -47,10 +47,15 @@ class TestCreateHashedSignedStatement(unittest.TestCase):
         subject = "testsubject"
         issuer = "testissuer"
         content_type = "application/json"
-        location_hint = "example-location"
+        payload_location = "example-location"
 
         signed_statement = create_hashed_signed_statement(
-            signing_key, payload, subject, issuer, content_type, location_hint
+            signing_key=signing_key, 
+            payload=payload, 
+            subject=subject, 
+            issuer=issuer, 
+            content_type=content_type, 
+            payload_location=payload_location
         )
 
         # decode the cbor encoded cose sign1 message
@@ -63,7 +68,7 @@ class TestCreateHashedSignedStatement(unittest.TestCase):
         self.assertEqual(
             -16, message.phdr[HEADER_LABEL_PAYLOAD_HASH_ALGORITHM]
         )  # -16 for sha256
-        self.assertEqual(location_hint, message.phdr[HEADER_LABEL_LOCATION])
+        self.assertEqual(payload_location, message.phdr[HEADER_LABEL_PAYLOAD_LOCATION])
 
         # get the verification key from cwt cnf
         cwt = message.phdr[HEADER_LABEL_CWT]


### PR DESCRIPTION
Synching to https://datatracker.ietf.org/doc/draft-steele-cose-hash-envelope/01/