### PR TITLE
Establish if explicit config is required to prevent merge on ci fail

### DIFF
--- a/unittests/test_create_signed_statement.py
+++ b/unittests/test_create_signed_statement.py
@@ -35,6 +35,10 @@ class TestCreateSignedStatement(unittest.TestCase):
         tests we can also verifiy that signed statement.
         """
 
+        # FORCE FAIL FOR CI EXPERIMENT
+
+        assert False is True
+
         # create the signed statement
         signing_key = SigningKey.generate(curve=NIST256p)
 


### PR DESCRIPTION
The build for this branch should always fail. We are using it to establish the minimum configuration required to ensure builds with failed CI builds can't be merged

AB#10153