### PR TITLE
Switch attestatons off

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -52,6 +52,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         verbose: true
+        attestations: false
         # skip-existing: true
         user: ${{ secrets.PYPI_USERNAME }}
         password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
We have not set up trusted publisher management for PyPi yet so switch attestations off for the moment