### PR TITLE
feat: support MMRIVER 02

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 build/
 dist/
 payload.json
+metadata.json
 scitt/artifacts/_manifest/*
 datatrails_scitt_samples/__pycache__/*
 datatrails_scitt_samples/scripts/__pycache__/*

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -124,7 +124,7 @@ tasks:
     cmds:
       - |
         set -e
-        source {{ .VENV_DIR }}/bin/activate
+        # DONT source the env here, it breaks the windows ci
 
         echo "DATATRAILS_ xxx var value char counts"
         echo "$DATATRAILS_URL" | wc -c

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -124,6 +124,7 @@ tasks:
     cmds:
       - |
         set -e
+        source {{ .VENV_DIR }}/bin/activate
 
         echo "DATATRAILS_ xxx var value char counts"
         echo "$DATATRAILS_URL" | wc -c

--- a/datatrails_scitt_samples/cbor_header_labels.py
+++ b/datatrails_scitt_samples/cbor_header_labels.py
@@ -52,7 +52,8 @@ HEADER_LABEL_COSE_RECEIPTS_INCLUSION_PROOFS = -1
 
 # MMRIVER headers
 # https://robinbryce.github.io/draft-bryce-cose-merkle-mountain-range-proofs/draft-bryce-cose-merkle-mountain-range-proofs.html#name-receipt-of-inclusion
-HEADER_LABEL_MMRIVER_VDS_TREE_ALG = 2
+HEADER_LABEL_MMRIVER_VDS_TREE_ALG_DRAFT_00 = 2
+HEADER_LABEL_MMRIVER_VDS_TREE_ALG = 3
 HEADER_LABEL_MMRIVER_INCLUSION_PROOF_INDEX = 1
 HEADER_LABEL_MMRIVER_INCLUSION_PROOF_PATH = 2
 


### PR DESCRIPTION
Notice: this changes the expected VDS from 2 to 3.

This change must not be released until the corresponding datatrails production release has shipped.

The registration-demo works when run against an updated avid & forstrie deployment.

**NOTICE** the ci currently points at a developer deployment. We will switch back to prod for the next release cycle